### PR TITLE
style: Correct crypt log statement

### DIFF
--- a/cpe_crypt/resources/cpe_crypt_authdb.rb
+++ b/cpe_crypt/resources/cpe_crypt_authdb.rb
@@ -25,7 +25,7 @@ action :manage do
   # First, validate whether or not the current settings are correct
   # Get current settings from authdb
   if crypt_currently_in_authdb && !uninstall?
-    log('Authdb already configured for Crypt')
+    Chef::Log.debug('Authdb already configured for Crypt')
     return
   end
   manage_crypt_authorizationdb

--- a/cpe_crypt/resources/cpe_crypt_install.rb
+++ b/cpe_crypt/resources/cpe_crypt_install.rb
@@ -39,7 +39,6 @@ action_class do
   end
 
   def crypt_installed?
-    Chef::Log.warn('Crypt binary not installed!')
     crypt_path =
       '/Library/Security/SecurityAgentPlugins/Crypt.bundle/Contents/MacOS/Crypt'
     ::File.exist?(crypt_path)


### PR DESCRIPTION
This first `log` to `Chef::Log.info` change will fix this cookbook from showing up as updating a resource on each run.

The second warn message shouldn't be printed any longer.
 
Fix: #3