### PR TITLE
feat: Add new managed setupassistant payload

### DIFF
--- a/cpe_setupassistant/README.md
+++ b/cpe_setupassistant/README.md
@@ -1,18 +1,19 @@
 cpe_setupassistant Cookbook
 =========================
 Install a profile to manage SetupAssistant settings.
+
 Requirements
 ------------
 Mac OS X
 
 Attributes
 ----------
-* node['cpe_setupassistant']
-* node['cpe_setupassistant']['DidSeeCloudSetup']
-* node['cpe_setupassistant']['DidSeeSiriSetup']
-* node['cpe_setupassistant']['LastSeenBuddyBuildVersion']
-* node['cpe_setupassistant']['LastSeenCloudProductVersion']
-* node['cpe_setupassistant']['RunNonInteractive']
+* node['cpe_setupassistant']['once']['DidSeeCloudSetup']
+* node['cpe_setupassistant']['once']['DidSeeSiriSetup']
+* node['cpe_setupassistant']['once']['LastSeenBuddyBuildVersion']
+* node['cpe_setupassistant']['once']['LastSeenCloudProductVersion']
+* node['cpe_setupassistant']['once']['RunNonInteractive']
+* node['cpe_setupassistant']['managed']['SkipCloudSetup']
 
 Usage
 -----
@@ -20,24 +21,27 @@ The profile will manage the `com.apple.SetupAssistant` preference domain.
 
 The profile's organization key defaults to `Pinterest` unless `node['organization']` is
 configured in your company's custom init recipe. The profile will also use
-whichever prefix is set in node['cpe_profiles']['prefix'], which defaults to `com.pinterest.chef`
+whichever prefix is set in node['cpe_profiles']['prefix'], which defaults to `com.facebook.chef`
 
-The profile delivers a payload of all keys in `node['cpe_setupassistant']` that are non-nil values.  The four provided keys `node['cpe_setupassistant']['DidSeeCloudSetup']`, `node['cpe_setupassistant']['LastSeenBuddyBuildVersion']`, `node['cpe_setupassistant']['LastSeenCloudProductVersion']` and `node['cpe_setupassistant']['RunNonInteractive']` are nil, so that no profile is installed by default.
+This cookbook can deliver a profile with two different payloads for configuring the Setup Assistant.  All keys are nil by default which will result in no profile being installed.  Common usage will be to use one or the other payload.
 
-You can add any arbitrary keys to `node['cpe_setupassistant']` to have them added to your profile.  As long as the values are not nil and create a valid profile, this cookbook will install and manage them.
+You can add any arbitrary keys to `node['cpe_setupassistant']['once']` to have them added to your profile.  As long as the values are not nil and create a valid profile, this cookbook will install and manage them. While `node['cpe_setupassistant']['once']`, at this time, only supports the 'SkipCloudSetup' key.
 
 The most common use case is for client machines that you want SetupAssistant to be disabled on. You can also use node attributes to dynamically update these fields without writing new code:
 
     # Disable SetupAssistant
-    node.default['cpe_setupassistant']['DidSeeCloudSetup'] = true
-    node.default['cpe_setupassistant']['LastSeenBuddyBuildVersion'] = '15G31'
-    node.default['cpe_setupassistant']['LastSeenCloudProductVersion'] = '10.11.6'
-    node.default['cpe_setupassistant']['RunNonInteractive'] = true
+    node.default['cpe_setupassistant']['once']['DidSeeCloudSetup'] = true
+    node.default['cpe_setupassistant']['once']['LastSeenBuddyBuildVersion'] = '15G31'
+    node.default['cpe_setupassistant']['once']['LastSeenCloudProductVersion'] = '10.11.6'
+    node.default['cpe_setupassistant']['once']['RunNonInteractive'] = true
 
     # Disable SetupAssistant (dynamic)
-    node.default['cpe_setupassistant']['DidSeeCloudSetup'] = true
-    node.default['cpe_setupassistant']['LastSeenBuddyBuildVersion'] =
+    node.default['cpe_setupassistant']['once']['DidSeeCloudSetup'] = true
+    node.default['cpe_setupassistant']['once']['LastSeenBuddyBuildVersion'] =
       node['platform_build']
-    node.default['cpe_setupassistant']['LastSeenCloudProductVersion'] =
+    node.default['cpe_setupassistant']['once']['LastSeenCloudProductVersion'] =
       node['platform_version']
-    node.default['cpe_setupassistant']['RunNonInteractive'] = true
+    node.default['cpe_setupassistant']['once']['RunNonInteractive'] = true
+
+    # Disable SetupAssistant. Only works on 10.10+
+    node.default['cpe_setupassistant']['managed']['SkipCloudSetup'] = true

--- a/cpe_setupassistant/attributes/default.rb
+++ b/cpe_setupassistant/attributes/default.rb
@@ -12,8 +12,11 @@
 #
 
 # Disable iCloud and SetupAssistant
-default['cpe_setupassistant']['DidSeeCloudSetup'] = nil
-default['cpe_setupassistant']['DidSeeSiriSetup'] = nil
-default['cpe_setupassistant']['LastSeenBuddyBuildVersion'] = nil
-default['cpe_setupassistant']['LastSeenCloudProductVersion'] = nil
-default['cpe_setupassistant']['RunNonInteractive'] = nil
+
+default['cpe_setupassistant']['once']['DidSeeCloudSetup'] = nil
+default['cpe_setupassistant']['once']['DidSeeSiriSetup'] = nil
+default['cpe_setupassistant']['once']['LastSeenBuddyBuildVersion'] = nil
+default['cpe_setupassistant']['once']['LastSeenCloudProductVersion'] = nil
+default['cpe_setupassistant']['once']['RunNonInteractive'] = nil
+
+default['cpe_setupassistant']['managed']['SkipCloudSetup'] = nil

--- a/cpe_setupassistant/resources/cpe_setupassistant.rb
+++ b/cpe_setupassistant/resources/cpe_setupassistant.rb
@@ -14,41 +14,70 @@
 resource_name :cpe_setupassistant
 default_action :run
 
-sa_prefs = {}
-
 action :run do
-  sa_prefs = node['cpe_setupassistant'].reject { |_k, v| v.nil? }
-  unless sa_prefs.empty?
-    organization = node['organization'] ? node['organization'] : 'Pinterest'
-    prefix = node['cpe_profiles']['prefix']
-    node.default['cpe_profiles']["#{prefix}.setupassistant"] = {
-      'PayloadIdentifier' => "#{prefix}.setupassistant",
-      'PayloadRemovalDisallowed' => true,
-      'PayloadScope' => 'System',
-      'PayloadType' => 'Configuration',
-      'PayloadUUID' => '552E2A87-2B97-4626-AAE1-DF2113960074',
-      'PayloadOrganization' => organization,
+  ss_once = node['cpe_setupassistant']['once'].reject { |_k, v| v.nil? }
+  ss_managed = node['cpe_setupassistant']['managed'].reject { |_k, v| v.nil? }
+  if ss_once.empty? && ss_managed.empty?
+    Chef::Log.info("#{cookbook_name}: No prefs found.")
+    return
+  end
+  prefix = node['cpe_profiles']['prefix']
+  organization = node['organization'] ? node['organization'] : 'Pinterest'
+  ss_profile = {
+    'PayloadIdentifier' => "#{prefix}.setupassistant",
+    'PayloadRemovalDisslowed' => true,
+    'PayloadScope' => 'System',
+    'PayloadType' => 'Configuration',
+    'PayloadUUID' => 'C552E2A87-2B97-4626-AAE1-DF2113960074',
+    'PayloadOrganization' => organization,
+    'PayloadVersion' => 1,
+    'PayloadDisplayName' => 'SetupAssistant',
+    'PayloadContent' => [],
+  }
+  # Set-Once settings
+  unless ss_once.empty?
+    ss_profile['PayloadContent'].push(
+      'PayloadType' => 'com.apple.ManagedClient.preferences',
       'PayloadVersion' => 1,
+      'PayloadIdentifier' => "#{prefix}.setupassistant",
+      'PayloadUUID' => '4CB98425-1FA5-46FE-B68C-DCDA1C7A6960',
+      'PayloadEnabled' => true,
       'PayloadDisplayName' => 'SetupAssistant',
-      'PayloadContent' => [
-        {
-          'PayloadType' => 'com.apple.ManagedClient.preferences',
-          'PayloadVersion' => 1,
-          'PayloadIdentifier' => "#{prefix}.setupassistant",
-          'PayloadUUID' => '4CB98425-1FA5-46FE-B68C-DCDA1C7A6960',
-          'PayloadEnabled' => true,
-          'PayloadDisplayName' => 'SetupAssistant',
-          'PayloadContent' => {
-            'com.apple.SetupAssistant' => {
-              'Set-Once' => [
-                {
-                  'mcx_preference_settings' => sa_prefs,
-                },
-              ],
-            },
+      'PayloadContent' => {
+        'PayloadType' => 'com.apple.ManagedClient.preferences',
+        'PayloadVersion' => 1,
+        'PayloadIdentifier' => "#{prefix}.setupassistant",
+        'PayloadUUID' => '4CB98425-1FA5-46FE-B68C-DCDA1C7A6960',
+        'PayloadEnabled' => true,
+        'PayloadDisplayName' => 'SetupAssistant',
+        'PayloadContent' => {
+          'com.apple.SetupAssistant' => {
+            'Set-Once' => [
+              {
+                'mcx_preference_settings' => ss_once,
+              },
+            ],
           },
         },
-      ],
-    }
+      },
+    )
   end
+  # Managed Settings
+  unless ss_managed.empty?
+    index = ss_profile['PayloadContent'].length
+    ss_profile['PayloadContent'].push(
+      'PayloadType' => 'com.apple.SetupAssistant.managed',
+      'PayloadVersion' => 1,
+      'PayloadIdentifier' => "#{prefix}.setupassistant.managed",
+      'PayloadUUID' => '4616f49c-5a67-4fb5-a3e5-c6855be7f8ba',
+      'PayloadEnabled' => true,
+      'PayloadDisplayName' => 'SetupAssistant',
+    )
+    ss_managed.keys.each do |key|
+      next if ss_managed[key].nil?
+      ss_profile['PayloadContent'][index][key] = ss_managed[key]
+    end
+  end
+
+  node.default['cpe_profiles']["#{prefix}.setupassistant"] = ss_profile
 end


### PR DESCRIPTION
This is a breaking api change since I've modified the old setup assistant to use `node['cpe_setupassistant']['once']`.

This allows us to use the 'SkipCloudSetup' key that was introduced in 10.10. [reference](https://github.com/rtrouton/profiles/blob/master/SkipiCloudSetup/SkipiCloudSetup.mobileconfig)
