### PR TITLE
cpe_firewall: Add Windows functionality for cross-platform joy

### DIFF
--- a/cpe_firewall/README.md
+++ b/cpe_firewall/README.md
@@ -16,7 +16,7 @@ Attributes
 
 Usage
 -----
-The profile will manage the `com.apple.security.firewall` preference domain.
+The profile will manage the `com.apple.security.firewall` preference domain for macOS nodes, and for Windows nodes it ensure that the `MpsSvc` service is set auto-start and that the service itself is running.
 
 The profile's organization key defaults to `Pinterest` unless `node['organization']` is
 configured in your company's custom init recipe. The profile will also use

--- a/cpe_firewall/metadata.rb
+++ b/cpe_firewall/metadata.rb
@@ -10,3 +10,4 @@ version '0.1.0'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'
+depends 'cpe_utils'

--- a/cpe_firewall/recipes/default.rb
+++ b/cpe_firewall/recipes/default.rb
@@ -11,5 +11,4 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-return if node.firewall_enabled?
 include_recipe "cpe_firewall::#{node['platform']}"

--- a/cpe_firewall/recipes/default.rb
+++ b/cpe_firewall/recipes/default.rb
@@ -11,4 +11,5 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-cpe_firewall 'Apply Firewall profile'
+return if node.firewall_enabled?
+include_recipe "cpe_firewall::#{node['platform']}"

--- a/cpe_firewall/recipes/mac_os_x.rb
+++ b/cpe_firewall/recipes/mac_os_x.rb
@@ -1,0 +1,16 @@
+#
+# Cookbook Name:: cpe_firewall
+# Recipe:: mac_os_x
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2017-present, Pinterest, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+return unless node.macos?
+
+cpe_firewall 'Apply Firewall profile'

--- a/cpe_firewall/recipes/windows.rb
+++ b/cpe_firewall/recipes/windows.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: cpe_firewall
+# Recipe:: windows
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2017-present, Pinterest, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+return unless node.windows?
+
+windows_service 'firewall' do
+  service_name 'MpsSvc'
+  run_as_user 'NT AUTHORITY\LocalService'
+  startup_type :automatic
+  action :start
+end


### PR DESCRIPTION
This PR, if merged, will add Windows functionality for this cookbook. Specifically, the Windows bits will ensure that the 'MpsSvc' (Windows Firewall) service:
1. Is set to start automatically
2. Is running

Note: This _does_ add a `cpe_utils` dependency which, although denoted as a prerequisite in this README, does not exist currently in the repository.