### PR TITLE
Add stagent hash to attributes file

### DIFF
--- a/cpe_softwareupdate/README.md
+++ b/cpe_softwareupdate/README.md
@@ -56,7 +56,7 @@ For example, you could tweak the above values
     node.default['cpe_softwareupdate']['su']['CriticalUpdateInstall'] = true
     # Disable TLS extended validation check
     node.default['cpe_softwareupdate']['su']['SUDisableEVCheck'] = true
-    # Enable automatatic macOS updates in Mojave
+    # Enable automatic macOS updates in Mojave
     node.default['cpe_softwareupdate']['su']['AutomaticallyInstallMacOSUpdates'] = true
-    # Enable automatic app store updates of instaled apps
+    # Enable automatic app store updates of installed apps
     node.default['cpe_softwareupdate']['stagent']['AutoUpdate'] = true

--- a/cpe_softwareupdate/attributes/default.rb
+++ b/cpe_softwareupdate/attributes/default.rb
@@ -17,9 +17,14 @@ default['cpe_softwareupdate'] = {
     'AutoUpdate' => nil,
     'AutoUpdateRestartRequired' => nil,
   },
+  # Store Agent
+  'stagent' => {
+    'AutoUpdate' => nil,
+  },
   # SoftwareUpdate
   'su' => {
     'AllowPreReleaseInstallation' => nil,
+    'AutomaticallyInstallMacOSUpdates' => nil,
     'AutomaticCheckEnabled' => nil,
     'AutomaticDownload' => nil,
     'CatalogURL' => nil,


### PR DESCRIPTION
Added missing `stagent` (referenced in the `README` as of previous commit) hash to default attributes file.

Fixed 2x small typo's in `README`.

🤙 shaka 🤙