### PR TITLE
Mod multi-if statement to if-elsif-else statment

### DIFF
--- a/cpe_crypt/resources/cpe_crypt_authdb.rb
+++ b/cpe_crypt/resources/cpe_crypt_authdb.rb
@@ -54,12 +54,12 @@ action_class do
 
   def manage_authdb?
     if uninstall?
-      return true
+      true
+    elsif install? && manage?
+      true
+    else
+      false
     end
-    if install? && manage?
-      return true
-    end
-    false
   end
 
   def authdb


### PR DESCRIPTION
This PR, if merged, will do two very small things:
1. It will modify the `manage_authdb?` function in `cpe_crypt/resources/cpe_crypt_authdb.rb`'s to use an `if`/`elsif`/`else` statement instead of using back-to-back `if` statements.
2. It removes the unnecessary `return` statement of this function's boolean evaluation.