### PR TITLE
add functionality to cpe_ard to actually manage RemoteManagement

### DIFF
--- a/cpe_ard/README.md
+++ b/cpe_ard/README.md
@@ -2,15 +2,34 @@ cpe_ard Cookbook
 =========================
 Install a profile to manage Apple Remote Desktop Application settings.
 
+This cookbook depends on the following cookbooks
+
+* cpe_profiles
+* cpe_utils
+* uber_helpers
+
+These cookbooks are offered by Facebook in the [IT-CPE](https://github.com/facebook/IT-CPE) repository and Uber in the [cpe-chef-cookbooks](https://github.com/uber/cpe-chef-cookbooks) repository.
+
 Requirements
 ------------
 Mac OS X
 
+Notes
+------------
+As of macOS 10.14 and higher, you cannot enforce the enablement of Apple Remote Desktop functionality without a TCC profile installed via UAMDM/DEP.
+
+Please follow this [KB article](https://support.apple.com/en-us/HT209161) to create the appropriate profile that chef will check against.
+
 Attributes
 ----------
 * node['cpe_ard']
-* node['cpe_ard']['AdminConsoleAllowsRemoteControl']
-* node['cpe_ard']['LoadRemoteManagementMenuExtra']
+* node['cpe_ard']['profile']['prefs']
+* node['cpe_ard']['profile']['prefs']['AdminConsoleAllowsRemoteControl']
+* node['cpe_ard']['profile']['prefs']['LoadRemoteManagementMenuExtra']
+* node['cpe_ard']['kickstart']
+* node['cpe_ard']['kickstart']['enable']
+* node['cpe_ard']['kickstart']['manage']
+* node['cpe_ard']['kickstart']['tcc_profile_id']
 
 Usage
 -----
@@ -26,6 +45,17 @@ You can add any arbitrary keys to `node['cpe_ard']` to have them added to your p
 
 The most common use case is for service machines with Apple Remote Desktop installed.
 
-    # Force Apple Remote Desktop use when application is open.
-    node.default['cpe_ard']['AdminConsoleAllowsRemoteControl'] = true
-    node.default['cpe_ard']['LoadRemoteManagementMenuExtra'] = true
+    # Force Apple Remote Desktop (Application) use when application is open.
+    node.default['cpe_ard']['profile']['prefs']['AdminConsoleAllowsRemoteControl'] = true
+    node.default['cpe_ard']['profile']['prefs']['LoadRemoteManagementMenuExtra'] = true
+
+    # Enable Apple Remote Desktop access
+    node.default['cpe_ard']['kickstart']['manage'] = true
+    node.default['cpe_ard']['kickstart']['enable'] = true
+    # TCC Profile identifier for 10.14 + machines
+    node.default['cpe_ard']['kickstart']['tcc_profile_id'] = 'your profile identifier'
+
+If you simply want to disable Apple Remote Desktop access.
+
+    # Disable Apple Remote Desktop access
+    node.default['cpe_ard']['kickstart']['manage'] = true

--- a/cpe_ard/attributes/default.rb
+++ b/cpe_ard/attributes/default.rb
@@ -11,6 +11,15 @@
 # LICENSE file in the root directory of this source tree.
 #
 default['cpe_ard'] = {
-  'AdminConsoleAllowsRemoteControl' => nil,
-  'LoadRemoteManagementMenuExtra' => nil,
+  'kickstart' => {
+    'enable' => false,
+    'manage' => false,
+    'tcc_profile_id' => nil, # string
+  },
+  'profile' => {
+    'prefs' => {
+      'AdminConsoleAllowsRemoteControl' => nil,
+      'LoadRemoteManagementMenuExtra' => nil,
+    },
+  },
 }

--- a/cpe_ard/metadata.rb
+++ b/cpe_ard/metadata.rb
@@ -10,3 +10,5 @@ version '0.1.0'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'
+depends 'cpe_utils'
+depends 'uber_helpers'

--- a/cpe_ard/recipes/default.rb
+++ b/cpe_ard/recipes/default.rb
@@ -11,4 +11,4 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-cpe_ard 'Apply Apple Remote Desktop App profile'
+cpe_ard 'Apply Apple Remote Desktop configurations'

--- a/cpe_ard/resources/cpe_ard.rb
+++ b/cpe_ard/resources/cpe_ard.rb
@@ -12,43 +12,121 @@
 #
 
 resource_name :cpe_ard
-default_action :run
+provides :cpe_ard, :platform => 'mac_os_x'
+default_action :manage
 
-# Enforce Apple Remote Desktop (Application) settings
-action :run do
-  ard_prefs = node['cpe_ard'].reject { |_k, v| v.nil? }
-  if ard_prefs.empty?
-    Chef::Log.info("#{cookbook_name}: No prefs found.")
-    return
+action :manage do
+  manage_profile
+  kickstart if node['cpe_ard']['kickstart']['manage']
+end
+
+action_class do # rubocop:disable Metrics/BlockLength
+  def manage_profile
+    ard_prefs = node['cpe_ard']['profile']['prefs'].reject { |_k, v| v.nil? }
+    if ard_prefs.empty?
+      Chef::Log.info("#{cookbook_name}: No prefs found - skipping profile "\
+        'enforcement')
+      return
+    end
+
+    prefix = node['cpe_profiles']['prefix']
+    # rubocop:disable Style/UnneededCondition
+    organization = node['organization'] ? node['organization'] : 'Pinterest'
+    # rubocop:enable Style/UnneededCondition
+    ard_profile = {
+      'PayloadIdentifier' => "#{prefix}.ardapp",
+      'PayloadRemovalDisallowed' => true,
+      'PayloadScope' => 'System',
+      'PayloadType' => 'Configuration',
+      'PayloadUUID' => '2CAB3C80-54C4-4D61-A142-52C2EBB0DA8C',
+      'PayloadOrganization' => organization,
+      'PayloadVersion' => 1,
+      'PayloadDisplayName' => 'Apple Remote Desktop Application',
+      'PayloadContent' => [],
+    }
+    unless ard_prefs.empty?
+      ard_profile['PayloadContent'].push(
+        'PayloadType' => 'com.apple.RemoteManagement',
+        'PayloadVersion' => 1,
+        'PayloadIdentifier' => "#{prefix}.ardapp",
+        'PayloadUUID' => '149EAD29-D27D-4639-8E8D-D8513B18A2B5',
+        'PayloadEnabled' => true,
+        'PayloadDisplayName' => 'Apple Remote Desktop Application',
+      )
+      ard_prefs.each_key do |key|
+        next if ard_prefs[key].nil?
+        ard_profile['PayloadContent'][0][key] = ard_prefs[key]
+      end
+    end
+
+    node.default['cpe_profiles']["#{prefix}.ard"] = ard_profile
   end
 
-  prefix = node['cpe_profiles']['prefix']
-  organization = node['organization'] ? node['organization'] : 'Pinterest'
-  ard_profile = {
-    'PayloadIdentifier' => "#{prefix}.ardapp",
-    'PayloadRemovalDisallowed' => true,
-    'PayloadScope' => 'System',
-    'PayloadType' => 'Configuration',
-    'PayloadUUID' => '2CAB3C80-54C4-4D61-A142-52C2EBB0DA8C',
-    'PayloadOrganization' => organization,
-    'PayloadVersion' => 1,
-    'PayloadDisplayName' => 'Apple Remote Desktop Application',
-    'PayloadContent' => [],
-  }
-  unless ard_prefs.empty?
-    ard_profile['PayloadContent'].push(
-      'PayloadType' => 'com.apple.RemoteManagement',
-      'PayloadVersion' => 1,
-      'PayloadIdentifier' => "#{prefix}.ardapp",
-      'PayloadUUID' => '149EAD29-D27D-4639-8E8D-D8513B18A2B5',
-      'PayloadEnabled' => true,
-      'PayloadDisplayName' => 'Apple Remote Desktop Application',
-    )
-    ard_prefs.each_key do |key|
-      next if ard_prefs[key].nil?
-      ard_profile['PayloadContent'][0][key] = ard_prefs[key]
+  def kickstart
+    if node['cpe_ard']['kickstart']['enable']
+      enable
+    else
+      disable
     end
   end
 
-  node.default['cpe_profiles']["#{prefix}.ard"] = ard_profile
+  def disable
+    # Disable ARD
+    execute 'Disable Apple Remote Desktop' do
+      command '/System/Library/CoreServices/RemoteManagement/ARDAgent.app/'\
+      'Contents/Resources/kickstart -deactivate -configure -access -off'
+      only_if { ard_server_running? }
+    end
+  end
+
+  def enable
+    # Enable ARD
+    # If running 10.14 and higher, we need a TCC profile installed with the
+    # appropriate configuration.
+    if node.os_at_least?('10.14')
+      tcc_profile_identifier = node['cpe_ard']['kickstart']['tcc_profile_id']
+      if tcc_profile_identifier.nil? || tcc_profile_identifier.empty?
+        # Bail if the attribute isn't set, or the command will fail.
+        Chef::Log.warn("#{cookbook_name}: Device is running 10.14 or higher "\
+          'and does not have necessary TCC profile chef attribute.')
+        return
+      else
+        # Bail if the profile doesn't exist with the correct configuration.
+        # https://support.apple.com/en-us/HT209161
+        unless node.profile_contains_content?(
+          'identifier \"com.apple.screensharing.agent\" and anchor apple',
+          tcc_profile_identifier,
+        )
+          Chef::Log.warn("#{cookbook_name}: Device is running 10.14 or higher "\
+            'and does not have necessary TCC profile installed with '\
+            'configuration for screensharing agent.')
+          return
+        end
+      end
+    end
+    execute 'Enable Apple Remote Desktop' do
+      command '/System/Library/CoreServices/RemoteManagement/ARDAgent.app'\
+      '/Contents/Resources/kickstart -activate -configure -allowAccessFor '\
+      '-allUsers -privs -all -clientopts -setmenuextra -menuextra no -restart '\
+      '-agent'
+      not_if { ard_server_running? }
+    end
+  end
+
+  def ard_server_running?
+    # There are only two methods documented online on how to check if ARD is
+    # running.
+    # 1. Using launchctl list as the currently logged in user
+    # 2. Various methods around grep | awk.
+    # Pgrep (while not ideal) allows us to remove the awk and grep. With newer
+    # versions of macOS, if we used launchctl we would have to do launchctl
+    # asuser UID launchctl list. This could also fail due to users not being
+    # logged in. This function allows it to work even at the loginwindow, since
+    # kickstart itself does not need this dependency to kickstart.
+    # Exit status of zero means it's on, exit 1 means it's off.
+    shell_out(
+      '/usr/bin/pgrep -f /System/Library/CoreServices/RemoteManagement/'\
+        'ARDAgent.app/Contents/MacOS/ARDAgent',
+    ).exitstatus.zero?
+  end
 end


### PR DESCRIPTION
This updates cpe_ard to actually manage parts of ARD beyond this simple profile.

Depends on `uber_helpers` which is now available at https://github.com/uber/cpe-chef-cookbooks/