### PR TITLE
refactor cpe_softwareupdate to require chef 14 and enable chef 15

### DIFF
--- a/cpe_softwareupdate/README.md
+++ b/cpe_softwareupdate/README.md
@@ -4,9 +4,12 @@ Install a profile to manage softwareupdate settings.
 
 Requirements
 ----------
-This cookbook requires the [mac_os_x](https://supermarket.chef.io/cookbooks/mac_os_x) cookbook.
+This cookbook requires Chef 14 and higher to run and depends on the following cookbooks:
 
-Please note that the above cookbook has been **deprecated** and does not work with Chef 14, though an [alternative version](https://github.com/erikng/mac_os_x) exists. This alternative version supports Chef 14, allowing you to continue to use this cookbook while upgrading your fleet of devices from prior versions of Chef.
+* cpe_profiles
+* cpe_utils
+
+These cookbooks are offered by Facebook in the [IT-CPE](https://github.com/facebook/IT-CPE) repository.
 
 Attributes
 ----------

--- a/cpe_softwareupdate/metadata.rb
+++ b/cpe_softwareupdate/metadata.rb
@@ -6,8 +6,8 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_softwareupdate'
 version '0.1.0'
+chef_version '>= 14.0' if respond_to?(:chef_version)
 supports 'mac_os_x'
 
 depends 'cpe_profiles'
 depends 'cpe_utils'
-depends 'mac_os_x'

--- a/cpe_softwareupdate/resources/cpe_softwareupdate.rb
+++ b/cpe_softwareupdate/resources/cpe_softwareupdate.rb
@@ -19,7 +19,6 @@ action :run do
   susu_prefs = node['cpe_softwareupdate']['su'].reject { |_k, v| v.nil? }
   suc_prefs = node['cpe_softwareupdate']['commerce'].reject { |_k, v| v.nil? }
   sta_prefs = node['cpe_softwareupdate']['stagent'].reject { |_k, v| v.nil? }
-  cv = node['chef_packages']['chef']['version']
   if susu_prefs.empty? && suc_prefs.empty? && sta_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return
@@ -51,18 +50,10 @@ action :run do
     susu_prefs.each_key do |key|
       next if susu_prefs[key].nil?
       su_profile['PayloadContent'][0][key] = susu_prefs[key]
-      if Gem::Version.new(cv) >= Gem::Version.new('14.0.0')
-        macos_userdefaults "Configure com.apple.SoftwareUpdate - #{key}" do
-          domain '/Library/Preferences/com.apple.SoftwareUpdate'
-          key key
-          value susu_prefs[key]
-        end
-      else
-        mac_os_x_userdefaults "Configure com.apple.SoftwareUpdate - #{key}" do
-          domain '/Library/Preferences/com.apple.SoftwareUpdate'
-          key key
-          value susu_prefs[key]
-        end
+      macos_userdefaults "Configure com.apple.SoftwareUpdate - #{key}" do
+        domain '/Library/Preferences/com.apple.SoftwareUpdate'
+        key key
+        value susu_prefs[key]
       end
     end
   end
@@ -80,18 +71,10 @@ action :run do
     suc_prefs.each_key do |key|
       next if suc_prefs[key].nil?
       su_profile['PayloadContent'][-1][key] = suc_prefs[key]
-      if Gem::Version.new(cv) >= Gem::Version.new('14.0.0')
-        macos_userdefaults "Configure com.apple.commerce - #{key}" do
-          domain '/Library/Preferences/com.apple.commerce'
-          key key
-          value suc_prefs[key]
-        end
-      else
-        mac_os_x_userdefaults "Configure com.apple.commerce - #{key}" do
-          domain '/Library/Preferences/com.apple.commerce'
-          key key
-          value suc_prefs[key]
-        end
+      macos_userdefaults "Configure com.apple.commerce - #{key}" do
+        domain '/Library/Preferences/com.apple.commerce'
+        key key
+        value suc_prefs[key]
       end
     end
   end
@@ -109,18 +92,10 @@ action :run do
     sta_prefs.each_key do |key|
       next if sta_prefs[key].nil?
       su_profile['PayloadContent'][-1][key] = sta_prefs[key]
-      if Gem::Version.new(cv) >= Gem::Version.new('14.0.0')
-        macos_userdefaults "Configure com.apple.storeagent - #{key}" do
-          domain '/Library/Preferences/com.apple.storeagent'
-          key key
-          value sta_prefs[key]
-        end
-      else
-        mac_os_x_userdefaults "Configure com.apple.storeagent - #{key}" do
-          domain '/Library/Preferences/com.apple.storeagent'
-          key key
-          value sta_prefs[key]
-        end
+      macos_userdefaults "Configure com.apple.storeagent - #{key}" do
+        domain '/Library/Preferences/com.apple.storeagent'
+        key key
+        value sta_prefs[key]
       end
     end
   end


### PR DESCRIPTION
This removes the need for my fork of mac_os_x cookbook, by enforcing chef 14 or higher.

This is necessary to enable Chef 15 compatibility.