### PR TITLE
Update checkin script to reflect latest commits to upstream crypt

### DIFF
--- a/cpe_crypt/files/crypt/checkin
+++ b/cpe_crypt/files/crypt/checkin
@@ -14,6 +14,7 @@ from distutils.version import LooseVersion
 import FoundationPlist
 
 from Foundation import NSDate
+from Foundation import NSArray
 from Foundation import CFPreferencesAppSynchronize
 from Foundation import CFPreferencesCopyAppValue
 from Foundation import CFPreferencesSetValue
@@ -84,7 +85,8 @@ def pref(pref_name):
         'RotateUsedKey': True,
         'OutputPath': '/private/var/root/crypt_output.plist',
         'ValidateKey': True,
-        'KeyEscrowInterval': 1
+        'KeyEscrowInterval': 1,
+        'AdditionalCurlOpts': []
     }
     pref_value = CFPreferencesCopyAppValue(pref_name, BUNDLE_ID)
     if pref_value is None:
@@ -96,6 +98,8 @@ def pref(pref_name):
     if isinstance(pref_value, NSDate):
         # convert NSDate/CFDates to strings
         pref_value = str(pref_value)
+    elif isinstance(pref_value, NSArray):
+        pref_value = list(pref_value)
     return pref_value
 
 
@@ -153,7 +157,11 @@ def escrow_key(plist):
     # written which then will be used as if they were written on the actual
     # command line.
     cmd = ['/usr/bin/curl', '--fail', '--silent',
-           '--show-error', '--location', '--config', '-']
+           '--show-error', '--location']
+    if pref('AdditionalCurlOpts') and isinstance(pref('AdditionalCurlOpts'), list):
+        for curl_opt in pref('AdditionalCurlOpts'):
+            cmd.append(curl_opt)
+    cmd.extend(['--config', '-'])
     task = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             stdin=subprocess.PIPE)
@@ -198,6 +206,13 @@ def using_recovery_key():
     """Check if FileVault is currently unlocked using
     the recovery key.
     """
+    macos_version = get_os_version(only_major_minor=False, as_tuple=False)
+
+    if LooseVersion(macos_version) >= LooseVersion('10.15'):
+        logging.info('Checking if using a recovery key is unstable on 10.15. '
+                     'Skipping.')
+        return False
+
     cmd = ['/usr/bin/fdesetup', 'usingrecoverykey']
     try:
         using_key = subprocess.check_output(cmd).strip()


### PR DESCRIPTION
Update the `checkin` script to include latest commit from @weswhet to skip checking if using the recovery key.
See: https://github.com/grahamgilbert/crypt/commit/740b542f16dcc69756647ecd1bd3e52d5a71f817#diff-aec70ca73e6f6749282ee21479003c58
