### PR TITLE
Add alternate acceptable platform value for macos

### DIFF
--- a/cpe_firewall/recipes/default.rb
+++ b/cpe_firewall/recipes/default.rb
@@ -11,6 +11,12 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-return unless node.macos? || node.windows?
+return unless node.windows? || node['platform'] == 'macos' || node['platform'] == 'mac_os_x'
 
-include_recipe "cpe_firewall::#{node['platform']}"
+if node.windows?
+  include_recipe 'cpe_firewall::windows'
+elsif node['platform'] == 'macos' || node['platform'] == 'mac_os_x'
+  include_recipe 'cpe_firewall::mac_os_x'
+else
+  Chef::Log.warn('cpe_firewall called on incompatible platform.')
+end


### PR DESCRIPTION
On some versions of Chef and macOS `node['platform']` (which underpins the `def macos?` node function from the `cpe_utils` library) returns `macos` instead of `mac_os_x`.

This will allow modern Chef versions (i.e. v14-v16) to work with this code on both Catalina and Big Sur.