### PR TITLE
Replace #Hash.reject with #Hash.compact

### DIFF
--- a/cpe_8021x/resources/cpe_8021x.rb
+++ b/cpe_8021x/resources/cpe_8021x.rb
@@ -16,9 +16,9 @@ default_action :run
 
 # Enforce 802.1x Settings
 action :run do
-  ethernet_prefs = node['cpe_8021x']['ethernet'].reject { |_k, v| v.nil? }
-  wifi_prefs = node['cpe_8021x']['wifi'].reject { |_k, v| v.nil? }
-  debug_prefs = node['cpe_8021x']['debug'].reject { |_k, v| v.nil? }
+  ethernet_prefs = node['cpe_8021x']['ethernet'].compact
+  wifi_prefs = node['cpe_8021x']['wifi'].compact
+  debug_prefs = node['cpe_8021x']['debug'].compact
   if ethernet_prefs.empty? && wifi_prefs.empty? && debug_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_applicationaccess/resources/cpe_applicationaccess.rb
+++ b/cpe_applicationaccess/resources/cpe_applicationaccess.rb
@@ -17,8 +17,8 @@ provides :cpe_applicationaccess, :os => 'darwin'
 default_action :run
 
 action :run do
-  aa_prefs = node['cpe_applicationaccess']['features'].reject { |_k, v| v.nil? }
-  aan_prefs = node['cpe_applicationaccess']['lists'].reject { |_k, v| v.nil? }
+  aa_prefs = node['cpe_applicationaccess']['features'].compact
+  aan_prefs = node['cpe_applicationaccess']['lists'].compact
   if aa_prefs.empty? && aan_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_ard/resources/cpe_ard.rb
+++ b/cpe_ard/resources/cpe_ard.rb
@@ -23,7 +23,7 @@ end
 
 action_class do # rubocop:disable Metrics/BlockLength
   def manage_profile
-    ard_prefs = node['cpe_ard']['profile']['prefs'].reject { |_k, v| v.nil? }
+    ard_prefs = node['cpe_ard']['profile']['prefs'].compact
     if ard_prefs.empty?
       Chef::Log.info("#{cookbook_name}: No prefs found - skipping profile "\
         'enforcement')

--- a/cpe_crypt/resources/cpe_crypt_profile.rb
+++ b/cpe_crypt/resources/cpe_crypt_profile.rb
@@ -20,7 +20,7 @@ action :config do
   return unless node['cpe_crypt']['install']
   return unless node['cpe_crypt']['profile']
 
-  crypt_prefs = node['cpe_crypt']['prefs'].reject { |_k, v| v.nil? }
+  crypt_prefs = node['cpe_crypt']['prefs'].compact
   if crypt_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_desktopwallpaper/resources/cpe_desktopwallpaper.rb
+++ b/cpe_desktopwallpaper/resources/cpe_desktopwallpaper.rb
@@ -17,7 +17,7 @@ default_action :run
 dw_prefs = {}
 
 action :run do
-  dw_prefs = node['cpe_desktopwallpaper'].reject { |_k, v| v.nil? }
+  dw_prefs = node['cpe_desktopwallpaper'].compact
   return if dw_prefs.empty?
   organization = node['organization'] ? node['organization'] : 'Pinterest'
   prefix = node['cpe_profiles']['prefix']

--- a/cpe_dock/resources/cpe_dock.rb
+++ b/cpe_dock/resources/cpe_dock.rb
@@ -15,7 +15,7 @@ resource_name :cpe_dock
 default_action :run
 
 action :run do
-  dock_prefs = node['cpe_dock'].reject { |_k, v| v.nil? }
+  dock_prefs = node['cpe_dock'].compact
   if dock_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_firewall/resources/cpe_firewall.rb
+++ b/cpe_firewall/resources/cpe_firewall.rb
@@ -18,7 +18,7 @@ default_action :run
 
 # Enforce firewall settings
 action :run do
-  fw_prefs = node['cpe_firewall'].reject { |_k, v| v.nil? }
+  fw_prefs = node['cpe_firewall'].compact
   if fw_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_gatekeeper/resources/cpe_gatekeeper.rb
+++ b/cpe_gatekeeper/resources/cpe_gatekeeper.rb
@@ -15,8 +15,8 @@ resource_name :cpe_gatekeeper
 default_action :run
 
 action :run do
-  gk_prefs = node['cpe_gatekeeper']['control'].reject { |_k, v| v.nil? }
-  gkm_prefs = node['cpe_gatekeeper']['managed'].reject { |_k, v| v.nil? }
+  gk_prefs = node['cpe_gatekeeper']['control'].compact
+  gkm_prefs = node['cpe_gatekeeper']['managed'].compact
   if gk_prefs.empty? && gkm_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_globalpreferences/resources/cpe_globalpreferences.rb
+++ b/cpe_globalpreferences/resources/cpe_globalpreferences.rb
@@ -17,7 +17,7 @@ provides :cpe_globalpreferences, :os => 'darwin'
 default_action :run
 
 action :run do
-  gp_prefs = node['cpe_globalpreferences'].reject { |_k, v| v.nil? }
+  gp_prefs = node['cpe_globalpreferences'].compact
   if gp_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_helloit/resources/cpe_helloit_profile.rb
+++ b/cpe_helloit/resources/cpe_helloit_profile.rb
@@ -21,7 +21,7 @@ action :config do
   return unless node['cpe_helloit']['install']
   return unless node['cpe_helloit']['profile']
 
-  hit_prefs = node['cpe_helloit']['prefs'].reject { |_k, v| v.nil? }
+  hit_prefs = node['cpe_helloit']['prefs'].compact
   if hit_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_kernelextensions/resources/cpe_kernelextensions.rb
+++ b/cpe_kernelextensions/resources/cpe_kernelextensions.rb
@@ -15,7 +15,7 @@ resource_name :cpe_kernelextensions
 default_action :run
 
 action :run do
-  ke_prefs = node['cpe_kernelextensions'].reject { |_k, v| v.nil? }
+  ke_prefs = node['cpe_kernelextensions'].compact
   if ke_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_loginwindow/resources/cpe_loginwindow.rb
+++ b/cpe_loginwindow/resources/cpe_loginwindow.rb
@@ -15,7 +15,7 @@ resource_name :cpe_loginwindow
 default_action :run
 
 action :run do
-  lw_prefs = node['cpe_loginwindow'].reject { |_k, v| v.nil? }
+  lw_prefs = node['cpe_loginwindow'].compact
   if lw_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_mcx/resources/cpe_mcx.rb
+++ b/cpe_mcx/resources/cpe_mcx.rb
@@ -17,7 +17,7 @@ default_action :run
 mcx_prefs = {}
 
 action :run do
-  mcx_prefs = node['cpe_mcx'].reject { |_k, v| v.nil? }
+  mcx_prefs = node['cpe_mcx'].compact
   return if mcx_prefs.empty?
   organization = node['organization'] ? node['organization'] : 'Pinterest'
   prefix = node['cpe_profiles']['prefix']

--- a/cpe_menulets/resources/cpe_menulets.rb
+++ b/cpe_menulets/resources/cpe_menulets.rb
@@ -15,7 +15,7 @@ resource_name :cpe_menulets
 default_action :run
 
 action :run do
-  ml_prefs = node['cpe_menulets'].reject { |_k, v| v.nil? }
+  ml_prefs = node['cpe_menulets'].compact
   if ml_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_passwordpolicy/resources/cpe_passwordpolicy.rb
+++ b/cpe_passwordpolicy/resources/cpe_passwordpolicy.rb
@@ -16,7 +16,7 @@ default_action :run
 
 # Enforce password policy and screensaver settings
 action :run do
-  pp_prefs = node['cpe_passwordpolicy'].reject { |_k, v| v.nil? }
+  pp_prefs = node['cpe_passwordpolicy'].compact
   if pp_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_preferencesecurity/resources/cpe_preferencesecurity.rb
+++ b/cpe_preferencesecurity/resources/cpe_preferencesecurity.rb
@@ -16,7 +16,7 @@ default_action :run
 
 # Enforce preference security settings
 action :run do
-  ps_prefs = node['cpe_preferencesecurity'].reject { |_k, v| v.nil? }
+  ps_prefs = node['cpe_preferencesecurity'].compact
   prefix = node['cpe_profiles']['prefix']
   organization = node['organization'] ? node['organization'] : 'Pinterest'
   ps_profile = {

--- a/cpe_screensaver/resources/cpe_screensaver.rb
+++ b/cpe_screensaver/resources/cpe_screensaver.rb
@@ -16,7 +16,7 @@ default_action :run
 
 # Enforce screen saver settings
 action :run do
-  ss_prefs = node['cpe_screensaver'].reject { |_k, v| v.nil? }
+  ss_prefs = node['cpe_screensaver'].compact
   if ss_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_setupassistant/resources/cpe_setupassistant.rb
+++ b/cpe_setupassistant/resources/cpe_setupassistant.rb
@@ -17,8 +17,8 @@ provides :cpe_setupassistant, :os => 'darwin'
 default_action :run
 
 action :run do
-  saonce_prefs = node['cpe_setupassistant']['once'].reject { |_k, v| v.nil? }
-  sam_prefs = node['cpe_setupassistant']['managed'].reject { |_k, v| v.nil? }
+  saonce_prefs = node['cpe_setupassistant']['once'].compact
+  sam_prefs = node['cpe_setupassistant']['managed'].compact
   if saonce_prefs.empty? && sam_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_smartcard/resources/cpe_smartcard.rb
+++ b/cpe_smartcard/resources/cpe_smartcard.rb
@@ -16,7 +16,7 @@ default_action :run
 
 # Enforce Smart Card settings
 action :run do
-  sc_prefs = node['cpe_smartcard'].reject { |_k, v| v.nil? }
+  sc_prefs = node['cpe_smartcard'].compact
   if sc_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_softwareupdate/resources/cpe_softwareupdate.rb
+++ b/cpe_softwareupdate/resources/cpe_softwareupdate.rb
@@ -18,9 +18,9 @@ default_action :run
 
 # Enforce SoftwareUpdate settings
 action :run do
-  susu_prefs = node['cpe_softwareupdate']['su'].reject { |_k, v| v.nil? }
-  suc_prefs = node['cpe_softwareupdate']['commerce'].reject { |_k, v| v.nil? }
-  sta_prefs = node['cpe_softwareupdate']['stagent'].reject { |_k, v| v.nil? }
+  susu_prefs = node['cpe_softwareupdate']['su'].compact
+  suc_prefs = node['cpe_softwareupdate']['commerce'].compact
+  sta_prefs = node['cpe_softwareupdate']['stagent'].compact
   if susu_prefs.empty? && suc_prefs.empty? && sta_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_submitdiaginfo/resources/cpe_submitdiaginfo.rb
+++ b/cpe_submitdiaginfo/resources/cpe_submitdiaginfo.rb
@@ -18,7 +18,7 @@ default_action :run
 
 # Enforce Submit Diag Info settings
 action :run do
-  sd_prefs = node['cpe_submitdiaginfo'].reject { |_k, v| v.nil? }
+  sd_prefs = node['cpe_submitdiaginfo'].compact
   if sd_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return

--- a/cpe_timemachine/resources/cpe_timemachine.rb
+++ b/cpe_timemachine/resources/cpe_timemachine.rb
@@ -16,8 +16,8 @@ default_action :run
 
 # Enforce Time Machine settings
 action :run do
-  tm_mcx_prefs = node['cpe_timemachine']['mcx'].reject { |_k, v| v.nil? }
-  tm_std_prefs = node['cpe_timemachine']['std'].reject { |_k, v| v.nil? }
+  tm_mcx_prefs = node['cpe_timemachine']['mcx'].compact
+  tm_std_prefs = node['cpe_timemachine']['std'].compact
   if tm_mcx_prefs.empty? && tm_std_prefs.empty?
     Chef::Log.info("#{cookbook_name}: No prefs found.")
     return


### PR DESCRIPTION
This PR will do one thing: Replace all instances of `#Hash.reject { |_k, v | v.nil? }` with `#Hash.compact`.

This has been shown (https://github.com/chef/chef/pull/10601) to increase speed by a reasonable amount and is a bit more simple (IMHO).

Tested this locally with Chef Solo and -- with a sample size of 4x runs -- our `run_list` went from an average run time of 30s (using `.reject`) to 24s (using `.compact`).