### PR TITLE
Enable `unified_mode`, set min Chef version on some cookbooks

### DIFF
--- a/cpe_applicationaccess/metadata.rb
+++ b/cpe_applicationaccess/metadata.rb
@@ -6,6 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Manages Apple System Preference Panes settings / profile'
 version '0.1.0'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'

--- a/cpe_applicationaccess/resources/cpe_applicationaccess.rb
+++ b/cpe_applicationaccess/resources/cpe_applicationaccess.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_applicationaccess
 provides :cpe_applicationaccess, :os => 'darwin'

--- a/cpe_ard/metadata.rb
+++ b/cpe_ard/metadata.rb
@@ -6,6 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Manages Apple Remote Desktop Application settings / profile'
 version '0.1.0'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'

--- a/cpe_ard/resources/cpe_ard.rb
+++ b/cpe_ard/resources/cpe_ard.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_ard
 provides :cpe_ard, :os => 'darwin'

--- a/cpe_crypt/metadata.rb
+++ b/cpe_crypt/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_crypt'
 version '0.1.0'
-chef_version '>= 12.6'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_launchd'

--- a/cpe_crypt/resources/cpe_crypt_authdb.rb
+++ b/cpe_crypt/resources/cpe_crypt_authdb.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_crypt_authdb
 provides :cpe_crypt_authdb, :os => 'darwin'

--- a/cpe_crypt/resources/cpe_crypt_install.rb
+++ b/cpe_crypt/resources/cpe_crypt_install.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_crypt_install
 provides :cpe_crypt_install, :os => 'darwin'

--- a/cpe_crypt/resources/cpe_crypt_ld.rb
+++ b/cpe_crypt/resources/cpe_crypt_ld.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_crypt_ld
 provides :cpe_crypt_ld, :os => 'darwin'

--- a/cpe_crypt/resources/cpe_crypt_profile.rb
+++ b/cpe_crypt/resources/cpe_crypt_profile.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_crypt_profile
 provides :cpe_crypt_profile, :os => 'darwin'

--- a/cpe_firewall/metadata.rb
+++ b/cpe_firewall/metadata.rb
@@ -6,6 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_firewall'
 version '0.1.0'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 supports 'windows'
 

--- a/cpe_firewall/resources/cpe_firewall.rb
+++ b/cpe_firewall/resources/cpe_firewall.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_firewall
 provides :cpe_firewall, :os => 'darwin'

--- a/cpe_globalpreferences/metadata.rb
+++ b/cpe_globalpreferences/metadata.rb
@@ -6,6 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Manages .GlobalPreferences settings / profile'
 version '0.1.0'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'

--- a/cpe_globalpreferences/resources/cpe_globalpreferences.rb
+++ b/cpe_globalpreferences/resources/cpe_globalpreferences.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_globalpreferences
 provides :cpe_globalpreferences, :os => 'darwin'

--- a/cpe_helloit/metadata.rb
+++ b/cpe_helloit/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_helloit'
 version '0.1.0'
-chef_version '>= 12.6'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_launchd'

--- a/cpe_helloit/resources/cpe_helloit_install.rb
+++ b/cpe_helloit/resources/cpe_helloit_install.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_helloit_install
 provides :cpe_helloit_install, :os => 'darwin'

--- a/cpe_helloit/resources/cpe_helloit_la.rb
+++ b/cpe_helloit/resources/cpe_helloit_la.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_helloit_la
 provides :cpe_helloit_la, :os => 'darwin'

--- a/cpe_helloit/resources/cpe_helloit_profile.rb
+++ b/cpe_helloit/resources/cpe_helloit_profile.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_helloit_profile
 provides :cpe_helloit_profile, :os => 'darwin'

--- a/cpe_screensaver/metadata.rb
+++ b/cpe_screensaver/metadata.rb
@@ -6,6 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_screensaver'
 version '0.1.0'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'

--- a/cpe_screensaver/resources/cpe_screensaver.rb
+++ b/cpe_screensaver/resources/cpe_screensaver.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_screensaver
 default_action :run

--- a/cpe_setupassistant/metadata.rb
+++ b/cpe_setupassistant/metadata.rb
@@ -6,6 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Manages SetupAssistant settings / profile'
 version '0.1.0'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'

--- a/cpe_setupassistant/resources/cpe_setupassistant.rb
+++ b/cpe_setupassistant/resources/cpe_setupassistant.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_setupassistant
 provides :cpe_setupassistant, :os => 'darwin'

--- a/cpe_softwareupdate/metadata.rb
+++ b/cpe_softwareupdate/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_softwareupdate'
 version '0.1.0'
-chef_version '>= 14.0' if respond_to?(:chef_version)
+chef_version '>= 14.14' if respond_to?(:chef_version)
 supports 'mac_os_x'
 
 depends 'cpe_profiles'

--- a/cpe_softwareupdate/resources/cpe_softwareupdate.rb
+++ b/cpe_softwareupdate/resources/cpe_softwareupdate.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_softwareupdate
 provides :cpe_softwareupdate, :os => 'darwin'

--- a/cpe_submitdiaginfo/metadata.rb
+++ b/cpe_submitdiaginfo/metadata.rb
@@ -6,6 +6,7 @@ maintainer_email 'itcpe@pinterest.com'
 license 'Apache-2.0'
 description 'Installs/Configures cpe_submitdiaginfo'
 version '0.1.0'
+chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'

--- a/cpe_submitdiaginfo/resources/cpe_submitdiaginfo.rb
+++ b/cpe_submitdiaginfo/resources/cpe_submitdiaginfo.rb
@@ -10,6 +10,7 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 #
+unified_mode true
 
 resource_name :cpe_submitdiaginfo
 provides :cpe_submitdiaginfo, :os => 'darwin'


### PR DESCRIPTION
This PR will do the following...
- Set `chef_version` (within each cookbooks' respective `metadata.rb`) to a minimum of v14.14
- Enable `unified_mode` on all custom resources within the cookbook
- Close #36 

...these changes have been applied to the following cookbooks:
- `cpe_applicationaccess`
- `cpe_ard`
- `cpe_crypt`
- `cpe_firewall`
- `cpe_globalpreferences`
- `cpe_helloit`
- `cpe_screensaver`
- `cpe_setupassistant`
- `cpe_softwareupdate`
- `cpe_submitdiaginfo`

As per the documentation on `unified_mode` (see: https://docs.chef.io/unified_mode/) the enablement of this feature should only cause problems under very specific circumstances (none of which I believe are at-play with these cookbooks).