### PR TITLE
Modify cpe_ard dependencies

### DIFF
--- a/cpe_ard/README.md
+++ b/cpe_ard/README.md
@@ -5,10 +5,10 @@ Install a profile to manage Apple Remote Desktop Application settings.
 This cookbook depends on the following cookbooks
 
 * cpe_profiles
-* cpe_utils
-* uber_helpers
+* cpe_helpers
+* fb_helpers
 
-These cookbooks are offered by Facebook in the [IT-CPE](https://github.com/facebook/IT-CPE) repository and Uber in the [cpe-chef-cookbooks](https://github.com/uber/cpe-chef-cookbooks) repository.
+These cookbooks are offered by Facebook in the [IT-CPE](https://github.com/facebook/IT-CPE) repository.
 
 Requirements
 ------------

--- a/cpe_ard/metadata.rb
+++ b/cpe_ard/metadata.rb
@@ -10,5 +10,5 @@ chef_version '>= 14.14'
 supports 'mac_os_x'
 
 depends 'cpe_profiles'
-depends 'cpe_utils'
-depends 'uber_helpers'
+depends 'cpe_helpers'
+depends 'fb_helpers'


### PR DESCRIPTION
The cpe_ard cookbook no longer relies on cpe_utils (deleted from Facebook upstream) or uber_helpers. The cookbook now relies on cpe_profiles, cpe_helpers, and fb_helpers. This change updates the metadata and README to reflect these changes.