### PR TITLE
Add provides to resources.

### DIFF
--- a/cpe_dock/resources/cpe_dock.rb
+++ b/cpe_dock/resources/cpe_dock.rb
@@ -11,6 +11,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+provides :cpe_dock
 resource_name :cpe_dock
 default_action :run
 unified_mode true

--- a/cpe_gatekeeper/resources/cpe_gatekeeper.rb
+++ b/cpe_gatekeeper/resources/cpe_gatekeeper.rb
@@ -11,6 +11,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+provides :cpe_gatekeeper
 resource_name :cpe_gatekeeper
 default_action :run
 unified_mode true

--- a/cpe_screensaver/resources/cpe_screensaver.rb
+++ b/cpe_screensaver/resources/cpe_screensaver.rb
@@ -12,6 +12,7 @@
 #
 unified_mode true
 
+provides :cpe_screensaver
 resource_name :cpe_screensaver
 default_action :run
 


### PR DESCRIPTION
I was playing around with [cookbook artifacts generated from a Policyfile](https://docs.chef.io/policyfile/#chef-export) and the chef zero run failed because these custom resources didn't have `provides` defined.